### PR TITLE
Use envsubst for manifest deployment

### DIFF
--- a/.github/workflows/gke-deploy.yml
+++ b/.github/workflows/gke-deploy.yml
@@ -90,4 +90,4 @@ jobs:
     # Deploy the API application
     - name: Deploy API application
       run: |
-        kubectl apply -f ./k8s/users-posts-api.yaml
+        envsubt < ./k8s/users-posts-api.yaml | kubectl apply -f -

--- a/.github/workflows/gke-deploy.yml
+++ b/.github/workflows/gke-deploy.yml
@@ -90,4 +90,4 @@ jobs:
     # Deploy the API application
     - name: Deploy API application
       run: |
-        envsubt < ./k8s/users-posts-api.yaml | kubectl apply -f -
+        envsubst < ./k8s/users-posts-api.yaml | kubectl apply -f -

--- a/k8s/users-posts-api.yaml
+++ b/k8s/users-posts-api.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: users-posts-api
-        image: gcr.io/redcellpartners.com/users-posts-api:latest
+        image: gcr.io/$PROJECT_ID/$IMAGE:$GITHUB_SHA
         ports:
         - containerPort: 8080
         env:


### PR DESCRIPTION
Manifest files have some env substitution that need to happen on deploy so test using `envsubst` when using GHA for deploying our API.